### PR TITLE
Table rows are clickable instead of just the details cell

### DIFF
--- a/src/layout/Navbar.tsx
+++ b/src/layout/Navbar.tsx
@@ -5,7 +5,6 @@ import logo from "@/assets/logo500x.png";
 import { Autocomplete } from "./components/Autocomplete";
 
 const NavButtons = {
-  Player: { text: "Player", link: "/player" },
   Quests: { text: "Quests", link: "/quests" },
 };
 

--- a/src/pages/player/Player.tsx
+++ b/src/pages/player/Player.tsx
@@ -186,30 +186,28 @@ const Player = () => {
                   )}
                 </div>
                 <ProfileWidget title={"Skills left to 99"}>
-                  <div className="grid grid-cols-6 gap-4">
+                  <div className="grid grid-cols-[repeat(auto-fit,minmax(30px,1fr))] gap-2 justify-center">
                     {!playerData &&
                       Array.from({ length: 5 }).map((_, index) => (
-                        <Skeleton
-                          key={index}
-                          className="h-5 w-[100%] col-span-6"
-                        />
+                        <Skeleton key={index} className="h-6 w-6 col-span-1" />
                       ))}
-                    {playerData?.skillvalues.map((skill) => {
-                      if (skill.level < 99) {
-                        return (
+                    {playerData?.skillvalues
+                      .filter((skill) => skill.level < 99)
+                      .map((skill) => (
+                        <div className="flex justify-center m-0 p-0">
                           <img
                             key={skill.id}
                             src={getSkillImage(skill.id)}
                             alt={getSkillName(skill.id)}
-                            className="h-6 w-6"
+                            className="h-6 w-6 object-contain"
                           />
-                        );
-                      }
-                    })}
+                        </div>
+                      ))}
                   </div>
                 </ProfileWidget>
+
                 <ProfileWidget title={"Skills left to 120"}>
-                  <div className="grid grid-cols-6 gap-4">
+                  <div className="grid grid-cols-[repeat(auto-fit,minmax(30px,1fr))] gap-2 justify-center">
                     {!playerData &&
                       Array.from({ length: 5 }).map((_, index) => (
                         <Skeleton
@@ -224,12 +222,14 @@ const Player = () => {
                         skill.xp / 10 < 104273167
                       ) {
                         return (
-                          <img
-                            key={skill.id}
-                            src={getSkillImage(skill.id)}
-                            alt={getSkillName(skill.id)}
-                            className="h-6 w-6"
-                          />
+                          <div className="flex justify-center m-0 p-0">
+                            <img
+                              key={skill.id}
+                              src={getSkillImage(skill.id)}
+                              alt={getSkillName(skill.id)}
+                              className="h-6 w-6"
+                            />
+                          </div>
                         );
                       }
                     })}

--- a/src/pages/player/components/PlayerStatsTable.tsx
+++ b/src/pages/player/components/PlayerStatsTable.tsx
@@ -86,7 +86,12 @@ const QuestTable = ({ playerData, loading }: PlayerStatsTableProps) => {
         </TableRow>
       </TableHeader>
       <TableBody>
-        <TableRow key={"total"}>
+        <TableRow
+          key={"total"}
+          onClick={() => {
+            toggleRow(-1);
+          }}
+        >
           <TableCell>
             <div className="flex items-center space-x-2">
               <img
@@ -106,19 +111,9 @@ const QuestTable = ({ playerData, loading }: PlayerStatsTableProps) => {
           <TableCell>
             <div className={"flex flex-row"}>
               {!!expandedRows[-1] ? (
-                <ChevronDown
-                  className={"border rounded"}
-                  onClick={() => {
-                    toggleRow(-1);
-                  }}
-                />
+                <ChevronDown className={"border rounded"} />
               ) : (
-                <ChevronRight
-                  className={"border rounded"}
-                  onClick={() => {
-                    toggleRow(-1);
-                  }}
-                />
+                <ChevronRight className={"border rounded"} />
               )}
             </div>
           </TableCell>
@@ -140,7 +135,12 @@ const QuestTable = ({ playerData, loading }: PlayerStatsTableProps) => {
           const isExpanded = !!expandedRows[skill.id];
           return (
             <>
-              <TableRow key={skill.id}>
+              <TableRow
+                key={skill.id}
+                onClick={() => {
+                  toggleRow(skill.id);
+                }}
+              >
                 <TableCell>
                   <div className="flex items-center space-x-2">
                     <img
@@ -161,19 +161,9 @@ const QuestTable = ({ playerData, loading }: PlayerStatsTableProps) => {
                 <TableCell>
                   <div className={"flex flex-row"}>
                     {isExpanded ? (
-                      <ChevronDown
-                        className={"border rounded"}
-                        onClick={() => {
-                          toggleRow(skill.id);
-                        }}
-                      />
+                      <ChevronDown className={"border rounded"} />
                     ) : (
-                      <ChevronRight
-                        className={"border rounded"}
-                        onClick={() => {
-                          toggleRow(skill.id);
-                        }}
-                      />
+                      <ChevronRight className={"border rounded"} />
                     )}
                   </div>
                 </TableCell>

--- a/src/pages/player/components/ProfileWidget.tsx
+++ b/src/pages/player/components/ProfileWidget.tsx
@@ -7,7 +7,7 @@ interface ProfileWidgetProps {
 
 const ProfileWidget = ({ children, title }: ProfileWidgetProps) => {
   return (
-    <div className="h-[250px] p-3 m-3 border-secondary border rounded-md">
+    <div className="h-auto p-3 m-3 border-secondary border rounded-md bg-background">
       {title && (
         <div
           className={

--- a/src/pages/player/components/QuestTable.tsx
+++ b/src/pages/player/components/QuestTable.tsx
@@ -256,7 +256,11 @@ const QuestTable = ({ playerData, filter }: QuestTableProps) => {
             );
 
             return (
-              <TableRow hidden={!isVisible} key={quest.name}>
+              <TableRow
+                hidden={!isVisible}
+                key={quest.name}
+                onClick={() => handleSheetOpen(quest.name)}
+              >
                 <TableCell>
                   <div className="flex flex-row ">
                     {questStatus === "COMPLETED" ? (
@@ -273,7 +277,7 @@ const QuestTable = ({ playerData, filter }: QuestTableProps) => {
                 </TableCell>
                 <TableCell>{quest.questPoints}</TableCell>
                 <TableCell>
-                  <EllipsisIcon onClick={() => handleSheetOpen(quest.name)} />
+                  <EllipsisIcon />
                 </TableCell>
               </TableRow>
             );

--- a/src/pages/questsPage/components/QuestTable.tsx
+++ b/src/pages/questsPage/components/QuestTable.tsx
@@ -84,13 +84,17 @@ const QuestTable = ({ filter }: QuestTableProps) => {
             );
 
             return (
-              <TableRow hidden={!isVisible} key={quest.name}>
+              <TableRow
+                hidden={!isVisible}
+                key={quest.name}
+                onClick={() => handleDisplayData(quest.name)}
+              >
                 <TableCell>
                   <span>{quest.name}</span>
                 </TableCell>
                 <TableCell>{quest.questPoints}</TableCell>
                 <TableCell>
-                  <EllipsisIcon onClick={() => handleDisplayData(quest.name)} />
+                  <EllipsisIcon />
                 </TableCell>
               </TableRow>
             );


### PR DESCRIPTION
This updates some of the UI and also allows you to click on the rows themselves to preform actions instead of having to click the individual button in the last cell of the row

This also updates the css styles for the skill widgets on the player page to adjust the size of the rows based on the size of the screen and will no longer lose their aspect ratio.